### PR TITLE
Show given name for a EcsSystems instead of just type name

### DIFF
--- a/Editor/EcsSystems.cs
+++ b/Editor/EcsSystems.cs
@@ -69,7 +69,7 @@ namespace Leopotam.Ecs.UnityIntegration.Editor {
                 string systemName;
                 var type = runItem.System.GetType ();
                 if (asSystems != null) {
-                    systemName = asSystems.Name ?? $"[{type.Name}]";
+                    systemName = $"[{asSystems.Name ?? type.Name}]";
                 } else {
                     systemName = type.Name;
                     if (type.IsGenericType) {

--- a/Editor/EcsSystems.cs
+++ b/Editor/EcsSystems.cs
@@ -69,7 +69,7 @@ namespace Leopotam.Ecs.UnityIntegration.Editor {
                 string systemName;
                 var type = runItem.System.GetType ();
                 if (asSystems != null) {
-                    systemName = $"[{type.Name}]";
+                    systemName = asSystems.Name ?? $"[{type.Name}]";
                 } else {
                     systemName = type.Name;
                     if (type.IsGenericType) {


### PR DESCRIPTION
It is better to see in the editor the given names for the EcsSystems instead of just type names. 
![EcsSystem_name](https://user-images.githubusercontent.com/426870/80285457-6cf8b600-8725-11ea-8987-f791a57684e5.png)
